### PR TITLE
Update run.sh - use regular gcc and ld

### DIFF
--- a/7/run.sh
+++ b/7/run.sh
@@ -1,12 +1,10 @@
-export PATH=$PATH:/usr/local/i386elfgcc/bin
-
 nasm "boot.asm" -f bin -o "Binaries/boot.bin"
 nasm "kernel_entry.asm" -f elf -o "Binaries/kernel_entry.o"
-i386-elf-gcc -ffreestanding -m32 -g -c "kernel.cpp" -o "Binaries/kernel.o"
+gcc -ffreestanding -m32 -g -c "kernel.cpp" -o "Binaries/kernel.o"
 nasm "zeroes.asm" -f bin -o "Binaries/zeroes.bin"
 
-i386-elf-ld -o "Binaries/full_kernel.bin" -Ttext 0x1000 "Binaries/kernel_entry.o" "Binaries/kernel.o" --oformat binary
+ld -m elf_i386 -o "Binaries/full_kernel.bin" -Ttext 0x1000 "Binaries/kernel_entry.o" "Binaries/kernel.o" --oformat binary --entry main --ignore-unresolved-symbol _GLOBAL_OFFSET_TABLE_
 
-cat "Binaries/boot.bin" "Binaries/full_kernel.bin" "Binaries/zeroes.bin"  > "Binaries/OS.bin"
+cat "Binaries/boot.bin" "Binaries/full_kernel.bin" "Binaries/zeroes.bin" >"Binaries/OS.bin"
 
-qemu-system-x86_64 -drive format=raw,file="Binaries/OS.bin",index=0,if=floppy,  -m 128M
+qemu-system-x86_64 -drive format=raw,file="Binaries/OS.bin",index=0,if=floppy, -m 128M


### PR DESCRIPTION
use regular `gcc` and `ld`

src:

- https://stackoverflow.com/a/64192367/15568835 - `--entry main`
- https://github.com/cfenollosa/os-tutorial/issues/16#issuecomment-323963322 - `--ignore-unresolved-symbol _GLOBAL_OFFSET_TABLE_`